### PR TITLE
🐛 fix(z.ai): 修正thinking思考内容客户端显示

### DIFF
--- a/app/providers/zai_provider.py
+++ b/app/providers/zai_provider.py
@@ -631,7 +631,7 @@ class ZAIProvider(BaseProvider):
                                             model,
                                             {
                                                 "role": "assistant",
-                                                "thinking": {"content": content}
+                                                "reasoning_content": content
                                             }
                                         )
                                         yield await self.format_sse_chunk(thinking_chunk)


### PR DESCRIPTION
- 将思考内容的字段名从 "thinking" 改为 "reasoning_content"
- 确保 ZAI 提供商的流式响应与 OpenAI 格式兼容