### PR TITLE
🔧 chore(core): 更新前端版本号和签名算法

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -74,7 +74,7 @@ class Settings(BaseSettings):
         "sec-ch-ua": '"Not;A=Brand";v="99", "Microsoft Edge";v="139", "Chromium";v="139"',
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": '"Windows"',
-        "X-FE-Version": "prod-fe-1.0.70",
+        "X-FE-Version": "prod-fe-1.0.98",
         "Origin": "https://chat.z.ai",
     }
 

--- a/app/core/zai_transformer.py
+++ b/app/core/zai_transformer.py
@@ -67,7 +67,7 @@ def get_zai_dynamic_headers(chat_id: str = "") -> Dict[str, str]:
         # UA and app-specific headers
         "User-Agent": user_agent,
         "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
-        "X-FE-Version": "prod-fe-1.0.79",
+        "X-FE-Version": "prod-fe-1.0.98",
         "Origin": "https://chat.z.ai",
     }
 

--- a/app/providers/zai_provider.py
+++ b/app/providers/zai_provider.py
@@ -70,7 +70,9 @@ def generate_signature(message_text: str, request_id: str, timestamp_ms: int, us
     r = str(timestamp_ms)
     e = f"requestId,{request_id},timestamp,{timestamp_ms},user_id,{user_id}"
     t = message_text or ""
-    i = f"{e}|{t}|{r}"
+    # Add content_base64 processing for new signature algorithm
+    content_base64 = base64.b64encode(t.encode('utf-8')).decode('ascii')
+    i = f"{e}|{content_base64}|{r}"
 
     window_index = timestamp_ms // (5 * 60 * 1000)
     root_key = (secret or "junjie").encode("utf-8")


### PR DESCRIPTION
- 更新 config.py 中的 X-FE-Version 从 prod-fe-1.0.70 到 prod-fe-1.0.98
- 更新 zai_transformer.py 中的 X-FE-Version 从 prod-fe-1.0.79 到 prod-fe-1.0.98
- 修改 zai_provider.py 中的签名生成算法，使用 base64 编码消息内容