### PR TITLE
fix: add SOCKS support to packaged httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "fastapi==0.116.1",
     "granian[reload,pname]==2.5.2",
-    "httpx[http2]==0.28.1",
+    "httpx[http2,socks]==0.28.1",
     "pydantic==2.11.7",
     "pydantic-settings==2.10.1",
     "pydantic-core==2.33.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 granian[reload,pname]==2.5.2
-httpx[http2]==0.28.1
+httpx[http2,socks]==0.28.1
 pydantic==2.11.7
 pydantic-settings==2.10.1
 pydantic-core==2.33.2

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_requirements_enable_httpx_socks_support():
+    requirements = (ROOT / "requirements.txt").read_text(encoding="utf-8")
+    assert "httpx[http2,socks]==0.28.1" in requirements
+
+
+def test_pyproject_enable_httpx_socks_support():
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert '"httpx[http2,socks]==0.28.1"' in pyproject


### PR DESCRIPTION
## Summary
- add the `socks` extra to the pinned `httpx` dependency in both `pyproject.toml` and `requirements.txt`
- add a small regression test so both install paths keep SOCKS support enabled

## Why
Issue #68 is valid: the codebase supports SOCKS proxies, but the packaged dependency only installed `httpx[http2]`. Installing from `requirements.txt` reproduced `ModuleNotFoundError: No module named 'socksio'`.

## Verification
- `pytest tests/test_dependency_metadata.py`
- created a temporary virtualenv, ran `pip install -r requirements.txt`, then verified `python -c "import socksio; print(socksio.__version__)"` succeeds

Closes #68